### PR TITLE
Refactor: add typed providers

### DIFF
--- a/src/SocialiteNET/Abstractions/ISocialite.cs
+++ b/src/SocialiteNET/Abstractions/ISocialite.cs
@@ -33,6 +33,7 @@ public interface ISocialite
     /// <returns>Provider instance</returns>
     /// <exception cref="ArgumentNullException">Thrown when config is null</exception>
     /// <exception cref="ArgumentException">Thrown when required config properties are missing</exception>
+    /// <exception cref="ArgumentOutOfRangeException">Thrown when provider is not supported</exception>
     IProvider BuildProvider(ProviderEnum provider, ProviderConfig config);
 
     /// <summary>

--- a/src/SocialiteNET/Abstractions/ISocialite.cs
+++ b/src/SocialiteNET/Abstractions/ISocialite.cs
@@ -23,7 +23,17 @@ public interface ISocialite
     /// <returns>Provider instance</returns>
     /// <exception cref="ArgumentNullException">Thrown when config is null</exception>
     /// <exception cref="ArgumentException">Thrown when required config properties are missing</exception>
-    IProvider BuildProvider(string provider, ProviderConfig config);
+    [Obsolete("Please use the GetProvider(ProviderEnum provider, ProviderConfig config) method")] IProvider BuildProvider(string provider, ProviderConfig config);
+
+    /// <summary>
+    /// Builds an OAuth provider with custom configuration
+    /// </summary>
+    /// <param name="provider">Provider type</param>
+    /// <param name="config">Provider configuration</param>
+    /// <returns>Provider instance</returns>
+    /// <exception cref="ArgumentNullException">Thrown when config is null</exception>
+    /// <exception cref="ArgumentException">Thrown when required config properties are missing</exception>
+    IProvider BuildProvider(ProviderEnum provider, ProviderConfig config);
 
     /// <summary>
     /// Adds a custom driver

--- a/src/SocialiteNET/Abstractions/ProviderEnum.cs
+++ b/src/SocialiteNET/Abstractions/ProviderEnum.cs
@@ -1,0 +1,17 @@
+namespace SocialiteNET.Abstractions;
+
+/// <summary>
+/// Enumeration of supported providers
+/// </summary>
+public enum ProviderEnum
+{
+    /// <summary>
+    /// Google authentication provider. Default provider.
+    /// </summary>
+    Google,
+
+    /// <summary>
+    /// GitHub authentication provider.
+    /// </summary>
+    Github,
+}

--- a/src/SocialiteNET/Core/SocialiteManager.cs
+++ b/src/SocialiteNET/Core/SocialiteManager.cs
@@ -170,7 +170,7 @@ public class SocialiteManager : ISocialite
 
                 return githubProvider;
             default:
-                throw new ArgumentOutOfRangeException(nameof(provider), provider, null);
+                throw new ArgumentOutOfRangeException(nameof(provider), provider, "Unsupported provider, please register a custom driver.");
         }
     }
 

--- a/src/SocialiteNET/Core/SocialiteManager.cs
+++ b/src/SocialiteNET/Core/SocialiteManager.cs
@@ -4,6 +4,8 @@ using System.Linq;
 using System.Net.Http;
 using Microsoft.Extensions.DependencyInjection;
 using SocialiteNET.Abstractions;
+using SocialiteNET.Providers.Github;
+using SocialiteNET.Providers.Google;
 
 namespace SocialiteNET.Core;
 
@@ -105,6 +107,71 @@ public class SocialiteManager : ISocialite
         }
 
         return providerInstance;
+    }
+
+    /// <inheritdoc />
+    public IProvider BuildProvider(ProviderEnum provider, ProviderConfig config)
+    {
+        ArgumentNullException.ThrowIfNull(config);
+
+        config.Validate();
+
+        using HttpClient httpClient = this.services.GetRequiredService<IHttpClientFactory>().CreateClient();
+
+        switch (provider)
+        {
+            case ProviderEnum.Google:
+                GoogleProvider googleProvider = new GoogleProvider(
+                    httpClient,
+                    config.ClientId,
+                    config.ClientSecret,
+                    config.RedirectUrl
+                );
+
+                if (config.Stateless)
+                {
+                    googleProvider.Stateless();
+                }
+
+                if (config.UsesPkce)
+                {
+                    googleProvider.WithPkce();
+                }
+
+                if (config.Parameters.Count > 0)
+                {
+                    googleProvider.With(config.Parameters);
+                }
+
+                return googleProvider;
+
+            case ProviderEnum.Github:
+                GitHubProvider githubProvider = new GitHubProvider(
+                    httpClient,
+                    config.ClientId,
+                    config.ClientSecret,
+                    config.RedirectUrl
+                );
+
+                if (config.Stateless)
+                {
+                    githubProvider.Stateless();
+                }
+
+                if (config.UsesPkce)
+                {
+                    githubProvider.WithPkce();
+                }
+
+                if (config.Parameters.Count > 0)
+                {
+                    githubProvider.With(config.Parameters);
+                }
+
+                return githubProvider;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(provider), provider, null);
+        }
     }
 
     /// <inheritdoc />

--- a/tests/SocialiteNET.UnitTests/Core/SocialiteManagerGoogleTests.cs
+++ b/tests/SocialiteNET.UnitTests/Core/SocialiteManagerGoogleTests.cs
@@ -88,6 +88,39 @@ public class SocialiteManagerGoogleTests
     }
 
     [Fact]
+    public void BuildProvider_WithTypedGoogleProviderConfig_ReturnsConfiguredGoogleProvider()
+    {
+        // Arrange
+        ServiceCollection services = [];
+
+        IHttpClientFactory? httpClientFactory = Substitute.For<IHttpClientFactory>();
+        httpClientFactory.CreateClient().Returns(new HttpClient());
+        services.AddSingleton(httpClientFactory);
+
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        SocialiteManager manager = new(serviceProvider);
+
+        ProviderConfig config = new()
+        {
+            ClientId = "test-client-id",
+            ClientSecret = "test-client-secret",
+            RedirectUrl = "https://example.com/callback",
+            Stateless = true,
+            UsesPkce = true
+        };
+        config.Scopes.Add("drive");
+        config.Parameters.Add("access_type", "offline");
+
+        // Act - This would typically fail in a real test as we can't create the type dynamically
+        // In a real test environment, we would need to mock or use real provider registration
+        var exception = Should.Throw<InvalidOperationException>(() =>
+            manager.BuildProvider(ProviderEnum.Google, config));
+
+        // Assert
+        exception.Message.ShouldBe("Provider [Google] could not be resolved.");
+    }
+
+    [Fact]
     public void Extend_WithGoogleProviderFactory_RegistersCustomDriver()
     {
         // Arrange


### PR DESCRIPTION
Problem: Building the providers requires the developer to provide a string as provider name and reflection to figure out which provider to build. This is slow and opened to mistakes.

Solution: I have added an enum to facilitate the selection of providers we currently support